### PR TITLE
Add custom options for TFTP.

### DIFF
--- a/.github/workflows/base-image-update.yml
+++ b/.github/workflows/base-image-update.yml
@@ -107,18 +107,20 @@ jobs:
         tags: kaczmar2/tftp-hpa-alpine:base-update-test
         load: true
         
-    - name: Test image can start
+    - name: Set up TFTP test environment
       run: |
-        # Create test directory
+        # Set up Docker bind mount
         sudo mkdir -p /srv/docker/tftp
         sudo chown -R $USER:$USER /srv/docker
         sudo chmod -R 755 /srv/docker/tftp
-        uname -a > /srv/docker/tftp/test
         
+    - name: Test image can start
+      run: |
         # Start container
         docker run -d \
           --name tftp-test \
           --network host \
+          -e TZ=America/Denver \
           -v /srv/docker/tftp:/srv/tftp \
           kaczmar2/tftp-hpa-alpine:base-update-test
           
@@ -137,6 +139,7 @@ jobs:
         cd /tmp
         
         # Test TFTP download
+        uname -a | sudo tee /srv/docker/tftp/test
         echo "get test" | tftp localhost
         
         # Verify file was downloaded and content matches

--- a/.github/workflows/base-image-update.yml
+++ b/.github/workflows/base-image-update.yml
@@ -163,12 +163,63 @@ jobs:
         # Check TFTP logs for request
         docker logs tftp-test | grep "RRQ from"
         
+    - name: Test TFTP upload functionality
+      run: |
+        # Stop existing container
+        docker stop tftp-test || true
+        docker rm tftp-test || true
+        
+        # Set permissions for upload testing
+        sudo chmod -R 777 /srv/docker/tftp
+        
+        # Start container with upload capability (--create flag)
+        docker run -d \
+          --name tftp-test \
+          --network host \
+          -e TZ=America/Denver \
+          -e TFTP_ARGS="--foreground --secure --create --verbosity 4 --user nobody" \
+          -v /srv/docker/tftp:/srv/tftp \
+          kaczmar2/tftp-hpa-alpine:base-update-test
+          
+        # Wait for startup
+        sleep 3
+        
+        # Test file upload
+        cd /tmp
+        echo "upload test content" > upload-test.txt
+        tftp localhost <<'EOF'
+        binary
+        put upload-test.txt
+        quit
+        EOF
+        
+        # Verify uploaded file exists and has correct content
+        if [ -f /srv/docker/tftp/upload-test.txt ]; then
+          echo "✅ File uploaded successfully"
+          if diff upload-test.txt /srv/docker/tftp/upload-test.txt; then
+            echo "✅ Uploaded file content matches"
+          else
+            echo "❌ Uploaded file content differs"
+            echo "Original file:"
+            cat upload-test.txt
+            echo "Uploaded file:"
+            cat /srv/docker/tftp/upload-test.txt
+            exit 1
+          fi
+        else
+          echo "❌ File was not uploaded"
+          exit 1
+        fi
+        
+        # Check TFTP logs for upload request
+        docker logs tftp-test | grep "WRQ from"
+        
     - name: Cleanup test container
       if: always()
       run: |
         docker stop tftp-test || true
         docker rm tftp-test || true
-        rm -f /tmp/test
+        rm -f /tmp/test /tmp/upload-test.txt
 
     - name: Login to Docker Hub
       uses: docker/login-action@v3

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,7 +2,7 @@ name: Docker Build, Test and Publish
 
 on:
   push:
-    branches: [ main ]
+    branches: [ "*" ]
     tags: 
       - v*
   pull_request:
@@ -34,17 +34,20 @@ jobs:
         tags: kaczmar2/tftp-hpa-alpine:test
         load: true
         
-    - name: Test image can start
+    - name: Set up TFTP test environment
       run: |
-        # Create test directory
+        # Set up Docker bind mount
         sudo mkdir -p /srv/docker/tftp
         sudo chown -R $USER:$USER /srv/docker
         sudo chmod -R 755 /srv/docker/tftp
         
+    - name: Test image can start
+      run: |
         # Start container
         docker run -d \
           --name tftp-test \
           --network host \
+          -e TZ=America/Denver \
           -v /srv/docker/tftp:/srv/tftp \
           kaczmar2/tftp-hpa-alpine:test
           
@@ -61,7 +64,7 @@ jobs:
       run: |
         # Test TFTP download
         cd /tmp
-        uname -a > /srv/docker/tftp/test
+        uname -a | sudo tee /srv/docker/tftp/test
         echo "get test" | tftp localhost
         
         # Verify file was downloaded and content matches
@@ -85,12 +88,60 @@ jobs:
         # Check TFTP logs for request
         docker logs tftp-test | grep "RRQ from"
         
+    - name: Test TFTP upload functionality
+      run: |
+        # Stop existing container
+        docker stop tftp-test || true
+        docker rm tftp-test || true
+        
+        # Start container with upload capability (--create flag)
+        docker run -d \
+          --name tftp-test \
+          --network host \
+          -e TZ=America/Denver \
+          -e TFTP_ARGS="--foreground --secure --create --verbosity 4 --user nobody" \
+          -v /srv/docker/tftp:/srv/tftp \
+          kaczmar2/tftp-hpa-alpine:test
+          
+        # Wait for startup
+        sleep 3
+        
+        # Test file upload
+        cd /tmp
+        echo "upload test content" > upload-test.txt
+        tftp localhost <<'EOF'
+        binary
+        put upload-test.txt
+        quit
+        EOF
+        
+        # Verify uploaded file exists and has correct content
+        if [ -f /srv/docker/tftp/upload-test.txt ]; then
+          echo "✅ File uploaded successfully"
+          if diff upload-test.txt /srv/docker/tftp/upload-test.txt; then
+            echo "✅ Uploaded file content matches"
+          else
+            echo "❌ Uploaded file content differs"
+            echo "Original file:"
+            cat upload-test.txt
+            echo "Uploaded file:"
+            cat /srv/docker/tftp/upload-test.txt
+            exit 1
+          fi
+        else
+          echo "❌ File was not uploaded"
+          exit 1
+        fi
+        
+        # Check TFTP logs for upload request
+        docker logs tftp-test | grep "WRQ from"
+        
     - name: Cleanup
       if: always()
       run: |
         docker stop tftp-test || true
         docker rm tftp-test || true
-        rm -f /tmp/test
+        rm -f /tmp/test /tmp/upload-test.txt
 
     - name: Login to Docker Hub
       if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -94,6 +94,9 @@ jobs:
         docker stop tftp-test || true
         docker rm tftp-test || true
         
+        # Set permissions for upload testing
+        sudo chmod -R 777 /srv/docker/tftp
+        
         # Start container with upload capability (--create flag)
         docker run -d \
           --name tftp-test \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ RUN apk add --no-cache tftp-hpa socat
 
 EXPOSE 69/udp
 
+# Set default TFTP arguments (can be overridden via environment variables)
+ENV TFTP_ARGS="--foreground --secure --verbosity 4 --user nobody"
+
 # Set up TFTP root directory
 RUN mkdir -p /srv/tftp && \
     chown nobody:nobody /srv/tftp && \
@@ -20,8 +23,8 @@ RUN echo '#!/bin/ash' > /start-tftp.sh && \
     echo 'echo "Starting tftpd..."' >> /start-tftp.sh && \
     echo 'socat -u UNIX-RECV:/dev/log STDOUT &' >> /start-tftp.sh && \
     echo 'sleep 1' >> /start-tftp.sh && \
-    echo 'echo "Executing: /usr/sbin/in.tftpd --foreground --secure --verbosity 4 --user nobody srv/tftp"' >> /start-tftp.sh && \
-    echo 'exec /usr/sbin/in.tftpd --foreground --secure --verbosity 4 --user nobody /srv/tftp' >> /start-tftp.sh && \
+    echo 'echo "Executing: /usr/sbin/in.tftpd ${TFTP_ARGS} /srv/tftp"' >> /start-tftp.sh && \
+    echo 'exec /usr/sbin/in.tftpd ${TFTP_ARGS} /srv/tftp' >> /start-tftp.sh && \
     chmod +x /start-tftp.sh
 
 CMD ["/start-tftp.sh"]

--- a/README.md
+++ b/README.md
@@ -48,6 +48,36 @@ docker run -d \
 
 ## Configuration
 
+### Customizing TFTP Options
+
+You can customize TFTP daemon behavior using the `TFTP_ARGS` environment variable. You can pass any valid `in.tftpd` options while keeping the current defaults:
+
+**Examples:**
+
+```bash
+# Enable file uploads (requires write permissions on mounted directory)
+docker run -d \
+  --name tftp-server \
+  --network host \
+  -e TFTP_ARGS="--foreground --secure --create --user nobody" \
+  -v /srv/docker/tftp:/srv/tftp \
+  kaczmar2/tftp-hpa-alpine
+
+# Additional options (timeout, umask, etc.)
+docker run -d \
+  --name tftp-server \
+  --network host \
+  -e TFTP_ARGS="--foreground --secure --create --timeout 300 --umask 022 --user nobody" \
+  -v /srv/docker/tftp:/srv/tftp \
+  kaczmar2/tftp-hpa-alpine
+```
+
+**Important limitations:**
+- Always include `--foreground --user nobody`
+- Don't use `--listen` as it conflicts with `--foreground`
+- Can't change the TFTP root directory from `/srv/tftp`
+- For uploads with `--create`, the container process needs write access to the mounted directory
+
 ### Docker Compose Setup
 
 ```yaml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     network_mode: host
     environment:
       - TZ=${TZ:-UTC}
+      # - TFTP_ARGS=${TFTP_ARGS:-}  # Optional: Override default TFTP arguments (uncomment to customize)
     volumes:
       - ${TFTP_ROOT:-/srv/docker/tftp}:/srv/tftp
       - /etc/localtime:/etc/localtime:ro


### PR DESCRIPTION
Dockerfile Changes:

  - Added TFTP_ARGS environment variable for configurable arguments
  - Updated startup script to use ${TFTP_ARGS} instead of hardcoded values
  - Default: "--foreground --secure --verbosity 4 --user nobody"

  🐳 docker-compose.yml Changes:

  - Added optional TFTP_ARGS environment variable (commented out by default)
  - Maintains consistency with Debian version

  🚀 GitHub Actions Workflow Enhancements:

  - Added "Set up TFTP test environment" step with proper directory setup
  - Enhanced testing with timezone environment variable (TZ=America/Denver)
  - Added comprehensive upload testing with --create flag
  - Fixed file creation to use sudo tee for proper permissions
  - Added cleanup for upload test files
  - Applied changes to both docker-build.yml and base-image-update.yml

  📚 README.md Enhancements:

  - Added "Customizing TFTP Options" section with examples
  - Documented TFTP_ARGS usage for uploads and advanced configuration
  - Added important limitations and security considerations
  - Maintained Alpine-specific user (nobody instead of tftp)

  🔍 Key Adaptations for Alpine:

  - User: nobody (Alpine) vs tftp (Debian)
  - All examples and documentation updated accordingly
  - Maintained functionality while respecting Alpine's user model